### PR TITLE
FIX: the validation on Use Status in rcsv/loadrentablecsv.go

### DIFF
--- a/rcsv/loadrentablecsv.go
+++ b/rcsv/loadrentablecsv.go
@@ -177,9 +177,9 @@ func CreateRentables(ctx context.Context, sa []string, lineno int) (int, error) 
 
 		var rst rlib.RentableStatus // struct for the data in this 3-tuple
 		ix, err := strconv.Atoi(ss[0])
-		if err != nil || ix < rlib.RENTABLESTATUSONLINE || ix > rlib.RENTABLESTATUSLAST {
+		if err != nil || ix < rlib.USESTATUSunknown || ix > rlib.USESTATUSLAST {
 			return CsvErrorSensitivity, fmt.Errorf("%s: line %d - invalid Status value: %s.  Must be in the range %d to %d",
-				funcname, lineno, ss[0], rlib.RENTABLESTATUSONLINE, rlib.RENTABLESTATUSLAST)
+				funcname, lineno, ss[0], rlib.USESTATUSunknown, rlib.USESTATUSLAST)
 		}
 		rst.UseStatus = int64(ix)
 


### PR DESCRIPTION
- Previously it was using old status value. But now it is using Use Status value for validation.